### PR TITLE
Feat: Add slide one todo

### DIFF
--- a/src/routes/TodoList/TodoList.module.scss
+++ b/src/routes/TodoList/TodoList.module.scss
@@ -8,6 +8,7 @@
   width: 360px;
   height: 720px;
   padding: 120px 40px 40px;
+  overflow: hidden;
   background-color: #fafbfe;
   border-radius: 60px;
 
@@ -26,7 +27,33 @@
     letter-spacing: 0.05em;
   }
 
+  .wrapTodo {
+    position: relative;
+  }
+
+  .taskSlide.slide {
+    right: -216px;
+  }
+
+  .taskSlide {
+    @include flexbox.flexbox(center center);
+    position: relative;
+    top: -46px;
+    right: -350px;
+    width: 15px;
+    height: 18px;
+    font-size: 15px;
+    transition: all 0.3s ease-in-out;
+  }
+
+  .task.slide {
+    left: -77px;
+    transition: all 0.3s ease-in-out;
+  }
+
   .task {
+    position: relative;
+    left: 0;
     display: flex;
     align-items: center;
     height: 72px;
@@ -34,6 +61,7 @@
     background-color: colors.$WHITE;
     border-radius: 32px;
     box-shadow: 0 10px 20px 0 rgba(colors.$BLACK, 2%);
+    transition: all 0.3s ease-in-out;
 
     + .task {
       margin-top: 18px;
@@ -76,12 +104,37 @@
       }
     }
 
+    .wrapTouch {
+      position: absolute;
+      left: 70px;
+      width: 210px;
+      height: 72px;
+      line-height: 72px;
+      cursor: default;
+    }
+
     .title {
       overflow: hidden;
       color: colors.$TASK_ITEM_TITLE;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+  }
+
+  .editButton {
+    padding: 18px 16px;
+    color: colors.$WHITE;
+    background-color: #cdcdcd;
+    border-radius: 10px 0 0 10px;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .deleteButton {
+    padding: 18px 16px;
+    color: colors.$WHITE;
+    background-color: #ff6b6b;
+    border-radius: 0 10px 10px 0;
+    transition: all 0.3s ease-in-out;
   }
 
   .addButton {

--- a/src/routes/TodoList/index.js
+++ b/src/routes/TodoList/index.js
@@ -66,7 +66,7 @@ function TodoList() {
         <ul className={styles.tasks}>
           <p className={styles.tasksTitle}>Today&apos;s</p>
           {todoList.map((todo) => (
-            <div className={styles.wrapTodo}>
+            <div key={`todoWrap-${todo.id}`} className={styles.wrapTodo}>
               <li key={`todo-${todo.id}`} className={cx(styles.task, {[styles.slide] : isTaskLeft && taskId === todo.id})}>
                 <div className={styles.checkboxWrapper}>
                   <input type='checkbox' checked={todo.done} data-id={todo.id} onChange={handleChange} />

--- a/src/routes/TodoList/index.js
+++ b/src/routes/TodoList/index.js
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import styles from './TodoList.module.scss'
 import { CheckIcon } from '../../assets/svgs'
+import classNames from 'classnames/bind'
+
+const cx = classNames.bind(styles)
 
 const INIT_TODO = [
   {
@@ -22,6 +25,23 @@ const INIT_TODO = [
 
 function TodoList() {
   const [todoList, setTodoList] = useState(INIT_TODO)
+  const [isTaskLeft, setIsTaskLeft] = useState(false)
+  const [taskId, setTaskId] = useState(0)
+
+  const handleTodoClick = (e, todoId) => {
+    setIsTaskLeft((prev)=>!prev)
+    setTaskId(()=>todoId)
+  }
+
+  const handleEditClick = () => {
+    setIsTaskLeft((prev)=>!prev)
+  }
+  
+  const handleDeleteClick = () => {
+    const deletedTodoList = todoList.filter(todo => taskId !== todo.id)
+    setTimeout(() => {setTodoList(()=>deletedTodoList)}, 200)
+    setIsTaskLeft((prev)=>!prev)
+  }
 
   const handleAddClick = (e) => {
     // console.log('handleAddClick')
@@ -46,13 +66,20 @@ function TodoList() {
         <ul className={styles.tasks}>
           <p className={styles.tasksTitle}>Today&apos;s</p>
           {todoList.map((todo) => (
-            <li key={`todo-${todo.id}`} className={styles.task}>
-              <div className={styles.checkboxWrapper}>
-                <input type='checkbox' checked={todo.done} data-id={todo.id} onChange={handleChange} />
-                <CheckIcon />
+            <div className={styles.wrapTodo}>
+              <li key={`todo-${todo.id}`} className={cx(styles.task, {[styles.slide] : isTaskLeft && taskId === todo.id})}>
+                <div className={styles.checkboxWrapper}>
+                  <input type='checkbox' checked={todo.done} data-id={todo.id} onChange={handleChange} />
+                  <CheckIcon />
+                </div>
+                <button type='button' className={styles.wrapTouch} onClick={(e) => handleTodoClick(e, todo.id)} aria-label='Todo Slide button'/>
+                <p className={styles.title}>{todo.title}</p>
+              </li>
+              <div className={cx(styles.taskSlide, {[styles.slide] : isTaskLeft && taskId === todo.id})}>
+                <button type='button' className={styles.editButton} onClick={handleEditClick}>Edit</button>
+                <button type='button' className={styles.deleteButton} onClick={handleDeleteClick}>Del </button>
               </div>
-              <p className={styles.title}>{todo.title}</p>
-            </li>
+            </div>
           ))}
         </ul>
         <button type='button' className={styles.addButton} onClick={handleAddClick} aria-label='Add button' />


### PR DESCRIPTION
### [메인 TODO 화면] - 수정/삭제 슬라이드
- todo 하나를 클릭했을 때 오른쪽에서 [수정][삭제] 버튼이 나오도록 구현하였습니다.

`TodoList/index.js`
- cx 추가
- todo 윗부분에 투명버튼 & 클릭이벤트 추가
- edit 버튼 & 클릭이벤트 추가
- delete 버튼 & 클릭이벤트 추가


클릭을 할 수 있게 만들기 위한 map 내부 구조 변경사항이 있습니다.
```
{todoList.map((todo) => (
  <li>
     ...
  </li>
)}
```
기존의 이런 구조에서
```
{todoList.map((todo) => (
  <div>
    <li>
       ...
    </li>
    <div>
      //버튼
    </div>
  </div>
)}
```
해당 구조로 변경하였습니다.



// .editButton #cdcdcd
// .deleteButton #ff6b6b